### PR TITLE
refactor: simple check url

### DIFF
--- a/src/shared/utils/url.ts
+++ b/src/shared/utils/url.ts
@@ -1,8 +1,5 @@
-export const isURL = (input: string): boolean => {
-  const pattern = /^(?:\w+:)?\/\/([^\s.]+\.\S{2}|localhost[:?\d]*)\S*$/;
+const pattern = /^(\w+:\/\/)?([^\s.]+\.\S{2}|localhost[:?\d]*)\S*$/;
 
-  if (pattern.test(input)) {
-    return true;
-  }
-  return pattern.test(`http://${input}`);
+export const isURL = (input: string): boolean => {
+  return pattern.test(input);
 };


### PR DESCRIPTION
- Don't need `?:` (no use match group)
- Don't need checking any protocol (use `?` to bypass protocol)
- Don't re-init `pattern` variable